### PR TITLE
ISSUE-315 :sparkles: Feat: 경쟁 세부기록 API ResponseData에 일지 제목 추가

### DIFF
--- a/src/app/api/competition/record/detail/route.ts
+++ b/src/app/api/competition/record/detail/route.ts
@@ -64,7 +64,7 @@ export async function GET(req: NextRequest) {
       .from('workout_diary')
       .select(
         `
-          id, created_at,
+          id, created_at, title,
           workout_record(
             set, weight, reps,
             workout_info(name)
@@ -95,6 +95,7 @@ export async function GET(req: NextRequest) {
 
         if (filteredRecord.length > 0) {
           scoreDetail.diary.push({
+            title: diaryElement.title,
             created_at: new Date(diaryElement.created_at),
             record: filteredRecord,
           })


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #315

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- 경쟁 세부기록 GET API에서 리턴되는 ResponseData에 일지 제목을 추가했습니다.

## ⌛ 소요 시간
