### PR TITLE
Issue 323 회원가입 flow 수정

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
     const cookieStore = cookies()
     const supabase = createClient(cookieStore)
 
-    const { email, password, nickname, birthdate, gender, location, preferred_sport } = await req.json()
+    const { email, password, nickname} = await req.json()
 
     if (!email || !password || !nickname) {
       return NextResponse.json(

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -9,46 +9,76 @@ export async function POST(req: NextRequest) {
     const supabase = createClient(cookieStore)
 
     const { email, password, nickname, birthdate, gender, location, preferred_sport } = await req.json()
-    const hashedPassword = await bcrypt.hash(password, 10)
 
-    if (
-      email.length === 0 ||
-      password.length === 0 ||
-      nickname.length === 0 ||
-      birthdate.length === 0 ||
-      gender.length === 0 ||
-      location.length === 0 ||
-      preferred_sport.length == 0
-    ) {
-      return NextResponse.json({ messsage: '유저 입력에 빈값이 존재합니다' }, { status: 400 })
+    if (!email || !password || !nickname) {
+      return NextResponse.json(
+        {
+          status: 400,
+          code: 'MISSING_REQUIRED_FIELDS',
+          message: '필수 입력 값이 누락되었습니다.',
+          details: null,
+        },
+        { status: 400 },
+      )
     }
 
-    const result = await supabase.from('member').insert({
+    const hashedPassword = await bcrypt.hash(password, 10)
+
+    const { data, error: insertError } = await supabase.from('member').insert({
       nickname,
       email,
-      birthdate,
       password: hashedPassword,
-      gender,
-      preferred_sport,
-      location,
       user_level: 1,
     })
 
-    if (result.error) {
-      return NextResponse.json({ message: '입력 안한 항목이 존재합니다.' }, { status: result.status })
+    if (insertError) {
+      return NextResponse.json(
+        {
+          status: 500,
+          code: insertError.code || 'INSERT_ERROR',
+          message: insertError.message || '회원 정보 저장 중 오류가 발생했습니다.',
+          details: insertError.hint || null, 
+        },
+        { status: 500 },
+      )
     }
 
+    // Supabase auth 가입 처리
     const { error: signUpError } = await supabase.auth.signUp({
       email,
       password,
     })
 
     if (signUpError) {
-      return NextResponse.json({ message: '회원가입에 실패하였습니다.' }, { status: signUpError.status })
+      return NextResponse.json(
+        {
+          status: 500,
+          code: 'SIGNUP_ERROR',
+          message: signUpError.message || '회원가입 처리 중 오류가 발생했습니다.',
+          details: null,
+        },
+        { status: 500 },
+      )
     }
 
-    return NextResponse.json({ message: '계정이 생성되었습니다' }, { status: 200 })
-  } catch (error) {
-    return NextResponse.json({ message: error }, { status: 400 })
+    return NextResponse.json(
+      {
+        status: 200,
+        code: 'SUCCESS',
+        message: '계정이 성공적으로 생성되었습니다.',
+        details: null,
+      },
+      { status: 200 },
+    )
+  } catch (error: any) {
+    return NextResponse.json(
+      {
+        status: 500,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: error.message || '서버 내부 오류가 발생했습니다.',
+        details: error.stack || null,
+      },
+      { status: 500 },
+    )
   }
 }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse, NextRequest } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { cookies } from 'next/headers'
+
+export async function POST(req: NextRequest) {
+  try {
+    const cookieStore = cookies()
+    const supabase = createClient(cookieStore)
+    const userId = req.headers.get('X-User-Id')
+
+    const { birthdate, preferredSport, location, gender } = await req.json()
+    console.log(birthdate, preferredSport, location, gender)
+    if (!birthdate || !preferredSport || !location || !gender) {
+      return NextResponse.json(
+        {
+          status: 400,
+          code: 'MISSING_REQUIRED_FIELDS',
+          message: '필수 입력 값이 누락되었습니다.',
+        },
+        { status: 400 },
+      )
+    }
+    const { data, error: insertError } = await supabase.from('member').update({
+      birthdate,
+      preferred_sport: preferredSport,
+      location,
+      gender,
+      user_level: 2,
+    }).eq('id', userId);
+
+    if (insertError) {
+    console.log(insertError)
+      return NextResponse.json(
+        {
+          status: 500,
+          code: insertError.code || 'DATABASE_INSERT_ERROR',
+          message: insertError.message || '회원 정보 저장 중 오류가 발생했습니다.',
+        },
+        { status: 500 },
+      )
+    }
+
+    return NextResponse.json(
+      {
+        status: 200,
+        code: 'SUCCESS',
+        message: '온보딩 정보가 성공적으로 저장되었습니다.',
+      },
+      { status: 200 },
+    )
+  } catch (error) {
+    console.log(error)
+    return NextResponse.json(
+      {
+        status: 500,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: error ? error : '서버 내부 오류가 발생했습니다.',
+      },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #323

## ✨ PR 세부 내용

- 회원가입 과정 분리
    - 회원가입 : 이메일, 비밀번호, 닉네임, 약관 동의 (userLevel:1)
    - 온보딩 : 선호운동, 위치, 성별, 생일
    - 온보딩까지 제출하고 나면, userLevel이 2가 되어서 온보딩이 다시 뜨지 않습니다.
- 첫 로그인 시(user level이 1인 경우) 온보딩으로 이동하는 모달을 띄우도록 했습니다.
- 로그인 할 때 비밀번호/이메일이 잘못된 경우 해당 오류가 전달되도록 했습니다. (원래는 그냥 서버오류로 떴음)

## ⌛ 소요 시간
