### PR TITLE
:sparkles: ISSUE-339: 애플 소셜 로그인 API 구현

### DIFF
--- a/src/app/api/social/login/apple/route.ts
+++ b/src/app/api/social/login/apple/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse, NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+
+export async function POST(req: NextRequest) {
+  try {
+    const cookieStore = cookies()
+    const supabase = createClient(cookieStore)
+
+    const { identityToken, nonce } = await req.json()
+
+    const { data, error } = await supabase.auth.signInWithIdToken({
+      provider: 'apple',
+      token: identityToken,
+      nonce: nonce,
+    })
+
+    if (error) {
+      return NextResponse.json({ message: error.message, status: error.status })
+    }
+    const { data: socialLoginData, error: socialLoginError } = await supabase
+      .from('social_login')
+      .select('*')
+      .eq('provider', 'apple')
+      .eq('provider_user_id', data.user.id)
+      .eq('email', data.user.email)
+      .single()
+
+    if (!socialLoginData) {
+      //처음 소셜로그인 하는사람 테이블등록
+      const { data: memberResult, error: memberError } = await supabase
+        .from('member')
+        .insert({
+          email: data.user.email,
+          user_level: 0,
+        })
+        .select('*')
+        .single()
+      if (memberError) {
+        return NextResponse.json({ message: memberError.message, status: 400 })
+      }
+      const member_id = memberResult.id
+      console.log(memberError, member_id)
+
+      const { data: socialLoginInsert, error: socialLoginInsertError } = await supabase
+        .from('social_login')
+        .insert({
+          provider: 'apple',
+          provider_user_id: data.user.id,
+          email: data.user.email,
+          member_id: member_id,
+        })
+        .select('*')
+        .single()
+      if (socialLoginInsertError) {
+        return NextResponse.json({ message: socialLoginInsertError.message, status: 400 })
+      }
+    }
+
+    return NextResponse.json({
+      status: 200,
+      message: '로그인 성공 !',
+    })
+  } catch (error) {
+    return NextResponse.json({ message: error })
+  }
+}
+
+//sdf

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -33,11 +33,13 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  if (request.nextUrl.pathname === '/api/login' || request.nextUrl.pathname === '/api/accounts') {
+  if (
+    request.nextUrl.pathname === '/api/login' ||
+    request.nextUrl.pathname === '/api/accounts' ||
+    request.nextUrl.pathname === '/api/social/login/apple'
+  ) {
     return supabaseResponse
-  }
-  // 요청하는 부분이 login API일경우
-  else {
+  } else {
     if (!user) {
       return NextResponse.json({ status: 403, message: '존재하지않는 유저입니다.' })
     } else {


### PR DESCRIPTION
## ✨ PR 세부 내용

로그인 Flow
1. 클라이언트에서 Apple로그인 성공후 token값과 nounce값을 서버에 보냄
2. 서버에서는 supabase.auth로 token값과 nounce를 signInWithIdToken으로 검증하고 유저 세션생성
3. 소셜로그인을 처음 이용하는 사용자인경우 테이블에 데이터등록
4. 소셜로그인을 처음 이용 x 로그인성공만반환

미들웨어를 통해 사용자 검증까지 다 가능합니다.